### PR TITLE
node-red-contrib-sm-8mosind: fix typo in package.json

### DIFF
--- a/node-red-contrib-sm-8mosind/8mosind.html
+++ b/node-red-contrib-sm-8mosind/8mosind.html
@@ -5,7 +5,7 @@
     </div>
     
     <div class="form-row">
-        <label for="node-input-mosfet"><i class="fa fa-empire"></i> Relay Number</label>
+        <label for="node-input-mosfet"><i class="fa fa-empire"></i> Mosfet Number</label>
         <input id="node-input-mosfet" class="8mosind-out-mosfet" placeholder="[msg.mosfet]" min=1 max=8 style="width:100px; height:16px;">
     </div>
     <div class="form-row">

--- a/node-red-contrib-sm-8mosind/package.json
+++ b/node-red-contrib-sm-8mosind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sm-8mosind",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "bundleDependencies": false,
   "dependencies": {
     "i2c-bus": "^5.2.0"
@@ -15,7 +15,7 @@
   "license": "MIT",
   "node-red" : {
     "nodes": {
-        "8relay": "8mosind.js"
+        "8mosind": "8mosind.js"
       }
   },
    "repository": {


### PR DESCRIPTION
change label from `Relay Number` to `Mosfet Number`

bump node-red-contrib-sm-8mosind package version

fixes #1 